### PR TITLE
实现自定义对象与模板占位符的绑定

### DIFF
--- a/Logging/src/Cosmos.Logging.RunsOn.Console/RendersLib/ConsoleHelloWorld.cs
+++ b/Logging/src/Cosmos.Logging.RunsOn.Console/RendersLib/ConsoleHelloWorld.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
+using Cosmos.Logging.Core.Extensions;
 using Cosmos.Logging.Formattings;
-using Cosmos.Logging.Formattings.Helpers;
 using Cosmos.Logging.Renders;
 
 namespace Cosmos.Logging.RunsOn.Console.RendersLib {
@@ -15,36 +14,23 @@ namespace Cosmos.Logging.RunsOn.Console.RendersLib {
         public bool IsNull => false;
 
         public void Render(string format, string paramsText, StringBuilder stringBuilder, IFormatProvider formatProvider = null) {
-            stringBuilder.Append(ToString(format, paramsText, formatProvider));
+            stringBuilder.Append(ToString(format, Content, formatProvider));
         }
 
         public void Render(IList<FormatEvent> formattingEvents, string paramsText, StringBuilder stringBuilder, IFormatProvider formatProvider = null) {
-            stringBuilder.Append(ToString(formattingEvents, paramsText, formatProvider));
+            stringBuilder.Append(ToString(formattingEvents, Content, formatProvider));
         }
 
         public void Render(IList<Func<object, IFormatProvider, object>> formattingFuncs, string paramsText, StringBuilder stringBuilder, IFormatProvider formatProvider = null) {
-            stringBuilder.Append(ToString(formattingFuncs, paramsText, formatProvider));
+            stringBuilder.Append(ToString(formattingFuncs, Content, formatProvider));
         }
 
         public string ToString(IList<FormatEvent> formattingEvents, string paramsText, IFormatProvider formatProvider = null) {
-            var content = Content;
-            if (formattingEvents == null || !formattingEvents.Any()) return content;
-            var ordered = formattingEvents.OrderBy(x => x.Sort);
-            foreach (var cmd in ordered) {
-                content = cmd.Command(content, formatProvider) as string;
-            }
-
-            return content;
+            return formattingEvents.ToFormat(Content, formatProvider);
         }
 
         public string ToString(IList<Func<object, IFormatProvider, object>> formattingFuncs, string paramsText, IFormatProvider formatProvider = null) {
-            var content = Content;
-            if (formattingFuncs == null || !formattingFuncs.Any()) return content;
-            foreach (var cmd in formattingFuncs) {
-                content = cmd(content, formatProvider) as string;
-            }
-
-            return content;
+            return formattingFuncs.ToFormat(Content, formatProvider);
         }
 
         public string ToString(string format, string paramsText, IFormatProvider formatProvider = null) {

--- a/Logging/src/Cosmos.Logging.Sinks.SampleLogSink/SampleLogPayloadClient.cs
+++ b/Logging/src/Cosmos.Logging.Sinks.SampleLogSink/SampleLogPayloadClient.cs
@@ -42,9 +42,9 @@ namespace Cosmos.Logging.Sinks.SampleLogSink {
                         }
                     }
 
-                    foreach (var token in logEvent.MessageTemplate.Tokens) {
-                        Console.WriteLine($"token={token}, type={token.TokenRenderType}, rawString={token.RawText}, tokenString={token.ToText()}");
-                    }
+//                    foreach (var token in logEvent.MessageTemplate.Tokens) {
+//                        Console.WriteLine($"token={token}, type={token.TokenRenderType}, rawString={token.RawText}, tokenString={token.ToText()}");
+//                    }
 
                     Console.WriteLine($"[{payload.Name}][{PadLeftByZero()(ix++)(count)('0')}][{GetLevelName()(Level)}] {stringBuilder}");
                 }

--- a/Logging/src/Cosmos.Logging/AdditionalOptContext.cs
+++ b/Logging/src/Cosmos.Logging/AdditionalOptContext.cs
@@ -17,6 +17,26 @@ namespace Cosmos.Logging {
             _additionalOperations.Add(opt);
         }
 
-        public LogEventSendMode SendMode { get; set; } = LogEventSendMode.Customize;
+        public AdditionalOptContext Opt(IAdditionalOperation opt) {
+            ImportOpt(opt);
+            return this;
+        }
+
+        internal LogEventSendMode SendMode { get; private set; } = LogEventSendMode.Customize;
+
+        public AdditionalOptContext FileAutomatically() {
+            SendMode = LogEventSendMode.Automatic;
+            return this;
+        }
+
+        public AdditionalOptContext FireManually() {
+            SendMode = LogEventSendMode.Manually;
+            return this;
+        }
+
+        public AdditionalOptContext FireAsDefault() {
+            SendMode = LogEventSendMode.Customize;
+            return this;
+        }
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/IMessagePropertyFactory.cs
+++ b/Logging/src/Cosmos.Logging/Core/IMessagePropertyFactory.cs
@@ -3,6 +3,6 @@ using Cosmos.Logging.MessageTemplates;
 
 namespace Cosmos.Logging.Core {
     public interface IMessagePropertyFactory {
-        MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalIndex = 0);
+        MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalValue = 0);
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/IMessagePropertyFactory.cs
+++ b/Logging/src/Cosmos.Logging/Core/IMessagePropertyFactory.cs
@@ -3,6 +3,6 @@ using Cosmos.Logging.MessageTemplates;
 
 namespace Cosmos.Logging.Core {
     public interface IMessagePropertyFactory {
-        MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int index = 0);
+        MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalIndex = 0);
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/IMessagePropertyValueFactory.cs
+++ b/Logging/src/Cosmos.Logging/Core/IMessagePropertyValueFactory.cs
@@ -3,6 +3,6 @@ using Cosmos.Logging.MessageTemplates;
 
 namespace Cosmos.Logging.Core {
     public interface IMessagePropertyValueFactory {
-        MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int index = 0);
+        MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1);
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/IMessagePropertyValueFactory.cs
+++ b/Logging/src/Cosmos.Logging/Core/IMessagePropertyValueFactory.cs
@@ -3,6 +3,6 @@ using Cosmos.Logging.MessageTemplates;
 
 namespace Cosmos.Logging.Core {
     public interface IMessagePropertyValueFactory {
-        MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1);
+        MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalValue = -1);
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/InternalLogger.cs
+++ b/Logging/src/Cosmos.Logging/Core/InternalLogger.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Cosmos.Logging.Core {
+    public static class InternalLogger {
+        public static void WriteLine(string message, params object[] args) {
+            Console.WriteLine($"{DateTime.UtcNow:O} {message}", args);
+        }
+    }
+}

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/Extensions/TypeFeelerExtensions.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/Extensions/TypeFeelerExtensions.cs
@@ -50,7 +50,7 @@ namespace Cosmos.Logging.Core.ObjectResolving.Extensions {
         }
 
         /// <summary>
-        /// Copy of Serilog.
+        /// One copy from Serilog.
         /// Author: Simon Cropp
         /// </summary>
         /// <param name="type"></param>

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterProcessor.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterProcessor.cs
@@ -22,8 +22,8 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             parsedProperties = _propertyBinder.Bind(parsedTemplate, messageProperties, out namedMessageProperties, out positionalMessageProperties);
         }
 
-        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalIndex = 0) {
-            return _messageParameterResolver.CreateProperty(name, value, mode, positionalIndex);
+        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalValue = 0) {
+            return _messageParameterResolver.CreateProperty(name, value, mode, positionalValue);
         }
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterProcessor.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterProcessor.cs
@@ -14,9 +14,12 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             _propertyBinder = new PropertyBinder(_messageParameterResolver);
         }
 
-        public void Process(string messageTemplate, object[] messageProperties, out MessageTemplate parsedTemplate, out IEnumerable<MessageProperty> parsedProperties) {
+        public void Process(string messageTemplate, object[] messageProperties, out MessageTemplate parsedTemplate,
+            out IEnumerable<MessageProperty> parsedProperties,
+            out Dictionary<(string name, PropertyResolvingMode mode), MessageProperty> namedMessageProperties,
+            out Dictionary<(int position, PropertyResolvingMode mode), MessageProperty> positionalMessageProperties) {
             parsedTemplate = _messageTemplateParser.Parse(messageTemplate);
-            parsedProperties = _propertyBinder.Bind(parsedTemplate, messageProperties);
+            parsedProperties = _propertyBinder.Bind(parsedTemplate, messageProperties, out namedMessageProperties, out positionalMessageProperties);
         }
 
         public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalIndex = 0) {

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterProcessor.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterProcessor.cs
@@ -19,8 +19,8 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             parsedProperties = _propertyBinder.Bind(parsedTemplate, messageProperties);
         }
 
-        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int index = 0) {
-            return _messageParameterResolver.CreateProperty(name, value, mode, index);
+        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalIndex = 0) {
+            return _messageParameterResolver.CreateProperty(name, value, mode, positionalIndex);
         }
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterResolver.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterResolver.cs
@@ -43,15 +43,15 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             _nestParameterResolver = new NestParameterResolver(_maxLevelOfNestLevelLimited, this);
         }
 
-        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int index = 0) {
-            return new MessageProperty(name, index, CreatePropertyValue(value, mode, index));
+        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalIndex = -1) {
+            return new MessageProperty(name, positionalIndex, CreatePropertyValue(value, mode, positionalIndex));
         }
 
-        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int index = 0) {
-            return CreatePropertyValue(value, mode, 1, index);
+        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1) {
+            return CreatePropertyValue(value, mode, 1, positionalIndex);
         }
 
-        internal MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int level, int index) {
+        internal MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int level, int positionalIndex) {
             if (value == null) return ReturnNullValue();
             if (mode == PropertyResolvingMode.Stringify) return ReturnStringifyValue(value);
             if (mode == PropertyResolvingMode.Destructure && value is string str) {
@@ -65,7 +65,7 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             if (_destructureResolveRules.TryResolve(value, mode, _nestParameterResolver, out var result1)) return result1;
             if (TypeFeeler.TryResolveToEnumerable(value, mode, _nestParameterResolver, typeOfValue, _maxLoopCountForCollection, out var result2)) return result2;
             if (TypeFeeler.TryResolveToValueTuple(value, mode, _nestParameterResolver, typeOfValue, out var result3)) return result3;
-            if (TypeFeeler.TryResolveCompilerGeneratedType(value, mode, _nestParameterResolver, typeOfValue, _raiseExceptions, index, out var result4)) return result4;
+            if (TypeFeeler.TryResolveCompilerGeneratedType(value, mode, _nestParameterResolver, typeOfValue, _raiseExceptions, positionalIndex, out var result4)) return result4;
 
             return ReturnDefaultValue(value);
         }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterResolver.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/MessageParameterResolver.cs
@@ -43,15 +43,15 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             _nestParameterResolver = new NestParameterResolver(_maxLevelOfNestLevelLimited, this);
         }
 
-        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalIndex = -1) {
-            return new MessageProperty(name, positionalIndex, CreatePropertyValue(value, mode, positionalIndex));
+        public MessageProperty CreateProperty(string name, object value, PropertyResolvingMode mode, int positionalValue = -1) {
+            return new MessageProperty(name, positionalValue, CreatePropertyValue(value, mode, positionalValue));
         }
 
-        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1) {
-            return CreatePropertyValue(value, mode, 1, positionalIndex);
+        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalValue = -1) {
+            return CreatePropertyValue(value, mode, 1, positionalValue);
         }
 
-        internal MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int level, int positionalIndex) {
+        internal MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int level, int positionalValue) {
             if (value == null) return ReturnNullValue();
             if (mode == PropertyResolvingMode.Stringify) return ReturnStringifyValue(value);
             if (mode == PropertyResolvingMode.Destructure && value is string str) {
@@ -65,7 +65,7 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             if (_destructureResolveRules.TryResolve(value, mode, _nestParameterResolver, out var result1)) return result1;
             if (TypeFeeler.TryResolveToEnumerable(value, mode, _nestParameterResolver, typeOfValue, _maxLoopCountForCollection, out var result2)) return result2;
             if (TypeFeeler.TryResolveToValueTuple(value, mode, _nestParameterResolver, typeOfValue, out var result3)) return result3;
-            if (TypeFeeler.TryResolveCompilerGeneratedType(value, mode, _nestParameterResolver, typeOfValue, _raiseExceptions, positionalIndex, out var result4)) return result4;
+            if (TypeFeeler.TryResolveCompilerGeneratedType(value, mode, _nestParameterResolver, typeOfValue, _raiseExceptions, positionalValue, out var result4)) return result4;
 
             return ReturnDefaultValue(value);
         }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/NestParameterResolver.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/NestParameterResolver.cs
@@ -22,7 +22,7 @@ namespace Cosmos.Logging.Core.ObjectResolving {
             return ret;
         }
 
-        MessagePropertyValue IMessagePropertyValueFactory.CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1) {
+        MessagePropertyValue IMessagePropertyValueFactory.CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex) {
             var _level = _currentNestLevel;
             var ret = ReturnDefaultIfMaxNestLevel(_level) ?? _root.CreatePropertyValue(value, mode, _level + 1, positionalIndex);
             _currentNestLevel = _level;

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/NestParameterResolver.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/NestParameterResolver.cs
@@ -15,17 +15,17 @@ namespace Cosmos.Logging.Core.ObjectResolving {
 
         public void SetNestLevel(int nestLevel) => _currentNestLevel = nestLevel;
 
-        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1) {
-            var _level = _currentNestLevel;
-            var ret = ReturnDefaultIfMaxNestLevel(_level) ?? _root.CreatePropertyValue(value, mode, _level + 1, positionalIndex);
-            _currentNestLevel = _level;
+        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalValue = -1) {
+            var level = _currentNestLevel;
+            var ret = ReturnDefaultIfMaxNestLevel(level) ?? _root.CreatePropertyValue(value, mode, level + 1, positionalValue);
+            _currentNestLevel = level;
             return ret;
         }
 
-        MessagePropertyValue IMessagePropertyValueFactory.CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex) {
-            var _level = _currentNestLevel;
-            var ret = ReturnDefaultIfMaxNestLevel(_level) ?? _root.CreatePropertyValue(value, mode, _level + 1, positionalIndex);
-            _currentNestLevel = _level;
+        MessagePropertyValue IMessagePropertyValueFactory.CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalValue) {
+            var level = _currentNestLevel;
+            var ret = ReturnDefaultIfMaxNestLevel(level) ?? _root.CreatePropertyValue(value, mode, level + 1, positionalValue);
+            _currentNestLevel = level;
             return ret;
         }
 

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/NestParameterResolver.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/NestParameterResolver.cs
@@ -15,16 +15,16 @@ namespace Cosmos.Logging.Core.ObjectResolving {
 
         public void SetNestLevel(int nestLevel) => _currentNestLevel = nestLevel;
 
-        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int index = 0) {
+        public MessagePropertyValue CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1) {
             var _level = _currentNestLevel;
-            var ret = ReturnDefaultIfMaxNestLevel(_level) ?? _root.CreatePropertyValue(value, mode, _level + 1, index);
+            var ret = ReturnDefaultIfMaxNestLevel(_level) ?? _root.CreatePropertyValue(value, mode, _level + 1, positionalIndex);
             _currentNestLevel = _level;
             return ret;
         }
 
-        MessagePropertyValue IMessagePropertyValueFactory.CreatePropertyValue(object value, PropertyResolvingMode mode, int index = 0) {
+        MessagePropertyValue IMessagePropertyValueFactory.CreatePropertyValue(object value, PropertyResolvingMode mode, int positionalIndex = -1) {
             var _level = _currentNestLevel;
-            var ret = ReturnDefaultIfMaxNestLevel(_level) ?? _root.CreatePropertyValue(value, mode, _level + 1, index);
+            var ret = ReturnDefaultIfMaxNestLevel(_level) ?? _root.CreatePropertyValue(value, mode, _level + 1, positionalIndex);
             _currentNestLevel = _level;
             return ret;
         }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/PropertyBinder.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/PropertyBinder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Cosmos.Logging.Events;
 using Cosmos.Logging.MessageTemplates;
@@ -7,14 +8,69 @@ using Cosmos.Logging.MessageTemplates;
 namespace Cosmos.Logging.Core.ObjectResolving {
     internal class PropertyBinder {
         private readonly MessageParameterResolver _messageParameterResolver;
+        private static readonly MessageProperty[] _emptyMessageProperties = new MessageProperty[0];
 
         public PropertyBinder(MessageParameterResolver resolver) {
             _messageParameterResolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
         }
 
         public IEnumerable<MessageProperty> Bind(MessageTemplate messageTemplate, object[] messageParameters) {
+            if (messageParameters == null || messageParameters.Length == 0) {
+                if (messageTemplate.PropertyClassTokenCount > 0)
+                    InternalLogger.WriteLine("No message parameters can be used for '{0}'.", messageTemplate);
+                return _emptyMessageProperties;
+            }
+
+            PrepareForPropertyToken(messageTemplate.Tokens, out var positionalPropertyMetaList, out var namedPropertyMetaList);
+            positionalPropertyMetaList = positionalPropertyMetaList.Where(x => x.position < messageParameters.Length).ToList();
+            var realLargestPosition = Math.Min(positionalPropertyMetaList.Select(x => x.position).Max(), messageParameters.Length);
+            
+            
+
+            var tokens = messageTemplate.TokenArray;
+
+            for (var index = 0; index < tokens.Length; index++) {
+                var token = tokens[index];
+                if (token is TextToken) continue;
+                if (token is NullPositionalPropertyToken) continue;
+
+                //todo
+            }
+
             Console.WriteLine("执行到 PropertyBinder.Bind，但目前尚在开发中...");
             return Enumerable.Empty<MessageProperty>();
+        }
+
+        void PrepareForPropertyToken(IEnumerable<MessageTemplateToken> tokens,
+            out List<(int position, PropertyResolvingMode mode)> positionalPropertyInfoList,
+            out List<(string name, PropertyResolvingMode mode)> namedPropertyInfoList) {
+
+            positionalPropertyInfoList = new List<(int, PropertyResolvingMode)>();
+            namedPropertyInfoList = new List<(string name, PropertyResolvingMode mode)>();
+
+            foreach (var token in tokens) {
+                if (token is PositionalPropertyToken propertyToken0 && propertyToken0.TokenRenderType == TokenRenderTypes.AsPositionalProperty) {
+                    var positionalValue = propertyToken0.PositionalParameterValue;
+                    var resolvingMode = propertyToken0.PropertyResolvingMode;
+                    if (!Exists0(positionalPropertyInfoList, positionalValue, resolvingMode)) {
+                        positionalPropertyInfoList.Add((positionalValue, resolvingMode));
+                    }
+                } else if (token is PropertyToken propertyToken1 && propertyToken1.TokenType == PropertyTokenTypes.UserDefinedParameter) {
+                    var name = propertyToken1.Name;
+                    var resolvingMode = propertyToken1.PropertyResolvingMode;
+                    if (!Exists1(namedPropertyInfoList, name, resolvingMode)) {
+                        namedPropertyInfoList.Add((name, resolvingMode));
+                    }
+                }
+            }
+
+            bool Exists0(IEnumerable<(int position, PropertyResolvingMode mode)> __infos, int position, PropertyResolvingMode mode) {
+                return __infos.Any(x => x.position == position && x.mode == mode);
+            }
+
+            bool Exists1(IEnumerable<(string name, PropertyResolvingMode mode)> __infos, string name, PropertyResolvingMode mode) {
+                return __infos.Any(x => x.name == name && x.mode == mode);
+            }
         }
     }
 }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/PropertyBinder.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/PropertyBinder.cs
@@ -66,10 +66,12 @@ namespace Cosmos.Logging.Core.ObjectResolving {
 
             var keysOfOutOfCachhed = namesHaveNotBeenCached.Select(x => x.Name);
             var namedPropMetaList2 = namedPropMetaList.Where(x => keysOfOutOfCachhed.Contains(x.name) && !namesHaveBeenCached.Contains(x.name)).ToList();
-            var __positional_offset_0 = Math.Max(
-                namesHaveNotBeenCached.Any() ? namesHaveNotBeenCached.Max(m => m.PositionalOffset) : 0,
-                legalPositionalPropMetaList.Select(x => x.position).Max());
-            var __real_max_positional_offset = Math.Min(__positional_offset_0, messageParameters.Length);
+
+            var __real_max_positional_offset = Math.Min(
+                Math.Max(
+                    namesHaveNotBeenCached.Any() ? namesHaveNotBeenCached.Max(m => m.PositionalOffset) : 0,
+                    legalPositionalPropMetaList.Any() ? legalPositionalPropMetaList.Select(x => x.position).Max() : 0),
+                messageParameters.Length);
 
             for (var __i = 0; __i <= __real_max_positional_offset; __i++) {
                 var __object = messageParameters[__i];

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/PropertyBinder.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/PropertyBinder.cs
@@ -1,52 +1,137 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using Cosmos.Logging.Events;
 using Cosmos.Logging.MessageTemplates;
 
+// ReSharper disable InconsistentNaming
 namespace Cosmos.Logging.Core.ObjectResolving {
     internal class PropertyBinder {
         private readonly MessageParameterResolver _messageParameterResolver;
-        private static readonly MessageProperty[] _emptyMessageProperties = new MessageProperty[0];
+
+        private static readonly MessageProperty[] _emptyMessageProperties;
+        private static readonly Dictionary<(string name, PropertyResolvingMode mode), MessageProperty> _emptyNamedMessageProperties;
+        private static readonly Dictionary<(int position, PropertyResolvingMode mode), MessageProperty> _emptyPositionalMessageProperties;
+
+        static PropertyBinder() {
+            _emptyMessageProperties = new MessageProperty[0];
+            _emptyNamedMessageProperties = new Dictionary<(string name, PropertyResolvingMode mode), MessageProperty>();
+            _emptyPositionalMessageProperties = new Dictionary<(int position, PropertyResolvingMode mode), MessageProperty>();
+        }
 
         public PropertyBinder(MessageParameterResolver resolver) {
             _messageParameterResolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
         }
 
-        public IEnumerable<MessageProperty> Bind(MessageTemplate messageTemplate, object[] messageParameters) {
+        public IEnumerable<MessageProperty> Bind(MessageTemplate messageTemplate, object[] messageParameters,
+            out Dictionary<(string name, PropertyResolvingMode mode), MessageProperty> namedMessageProperties,
+            out Dictionary<(int position, PropertyResolvingMode mode), MessageProperty> positionalMessageProperties) {
+
             if (messageParameters == null || messageParameters.Length == 0) {
                 if (messageTemplate.PropertyClassTokenCount > 0)
                     InternalLogger.WriteLine("No message parameters can be used for '{0}'.", messageTemplate);
+                namedMessageProperties = _emptyNamedMessageProperties;
+                positionalMessageProperties = _emptyPositionalMessageProperties;
                 return _emptyMessageProperties;
             }
 
-            PrepareForPropertyToken(messageTemplate.Tokens, out var positionalPropertyMetaList, out var namedPropertyMetaList);
-            positionalPropertyMetaList = positionalPropertyMetaList.Where(x => x.position < messageParameters.Length).ToList();
-            var realLargestPosition = Math.Min(positionalPropertyMetaList.Select(x => x.position).Max(), messageParameters.Length);
-            
-            
+            var __result = new List<MessageProperty>();
+            var __named_cache = new Dictionary<(string name, PropertyResolvingMode mode), MessageProperty>();
+            var __positional_cache = new Dictionary<(int position, PropertyResolvingMode mode), MessageProperty>();
 
-            var tokens = messageTemplate.TokenArray;
+            PrepareForPropertyToken(messageTemplate.Tokens, out var positionalPropMetaList, out var namedPropMetaList, out var namedPropOffsetInfoDict);
 
-            for (var index = 0; index < tokens.Length; index++) {
-                var token = tokens[index];
-                if (token is TextToken) continue;
-                if (token is NullPositionalPropertyToken) continue;
-
-                //todo
+            var anonymousParamObjects = messageParameters.Where(x => x.GetType().Name.StartsWith("<>"));
+            foreach (var __anonymous in anonymousParamObjects) {
+                var propertiesInAnonymus = __anonymous.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetField | BindingFlags.GetProperty);
+                foreach (var propertyInAnonymus in propertiesInAnonymus) {
+                    var __anonymous_name = propertyInAnonymus.Name;
+                    if (string.IsNullOrWhiteSpace(__anonymous_name) || __anonymous_name.StartsWith("<>")) continue;
+                    if (__named_cache.Any(x => x.Key.name == __anonymous_name)) continue;
+                    if (namedPropMetaList.Any(x => string.Compare(x.name, __anonymous_name, StringComparison.OrdinalIgnoreCase) == 0)) {
+                        var __matched_keys = namedPropMetaList.Where(x => string.Compare(x.name, __anonymous_name, StringComparison.OrdinalIgnoreCase) == 0);
+                        var __object = propertyInAnonymus.GetValue(__anonymous);
+                        foreach (var __key in __matched_keys) {
+                            __update0(__key, __object);
+                        }
+                    }
+                }
             }
 
-            Console.WriteLine("执行到 PropertyBinder.Bind，但目前尚在开发中...");
-            return Enumerable.Empty<MessageProperty>();
+            var legalPositionalPropMetaList = positionalPropMetaList.Where(x => x.position < messageParameters.Length).ToList();
+            var namesHaveBeenCached = __named_cache.Select(x => x.Key.name).Distinct().ToList();
+            var namesHaveNotBeenCached = namedPropOffsetInfoDict.Where(o => !namesHaveBeenCached.Contains(o.Key) && o.Value < messageParameters.Length)
+                .Select(s => new {PositionalOffset = s.Value, Name = s.Key}).ToList();
+
+            var keysOfOutOfCachhed = namesHaveNotBeenCached.Select(x => x.Name);
+            var namedPropMetaList2 = namedPropMetaList.Where(x => keysOfOutOfCachhed.Contains(x.name) && !namesHaveBeenCached.Contains(x.name)).ToList();
+            var __positional_offset_0 = Math.Max(
+                namesHaveNotBeenCached.Any() ? namesHaveNotBeenCached.Max(m => m.PositionalOffset) : 0,
+                legalPositionalPropMetaList.Select(x => x.position).Max());
+            var __real_max_positional_offset = Math.Min(__positional_offset_0, messageParameters.Length);
+
+            for (var __i = 0; __i <= __real_max_positional_offset; __i++) {
+                var __object = messageParameters[__i];
+                var ____i = __i;
+
+                foreach (var item in namesHaveNotBeenCached.Where(x => x.PositionalOffset == ____i)) {
+                    var __keys = namedPropMetaList2.Where(x => x.name == item.Name);
+                    foreach (var __key in __keys) {
+                        __update1(__key, __object, ____i);
+                    }
+                }
+
+                foreach (var __key in legalPositionalPropMetaList.Where(x => x.position == ____i)) {
+                    __update2(__key, __object);
+                }
+            }
+
+            namedMessageProperties = __named_cache;
+            positionalMessageProperties = __positional_cache;
+            return __result;
+
+            void __update0((string name, PropertyResolvingMode mode) __key, object __object) {
+                if (!__named_cache.ContainsKey(__key)) {
+                    var __compiled = _messageParameterResolver.CreateProperty(__key.name, __object, __key.mode);
+                    __named_cache.Add(__key, __compiled);
+                    __result.Add(__compiled);
+                }
+            }
+
+            void __update1((string name, PropertyResolvingMode mode) __key, object __object, int __position) {
+                if (!__named_cache.ContainsKey(__key)) {
+                    var __key_alias_0 = ($"__cosmos_<>position_{__position}", __key.mode);
+                    var __key_alias_1 = (__position, __key.mode);
+                    var __compiled = _messageParameterResolver.CreateProperty(__key.name, __object, __key.mode, __position);
+                    __named_cache.Add(__key, __compiled);
+                    __named_cache.Add(__key_alias_0, __compiled);
+                    __positional_cache.Add(__key_alias_1, __compiled);
+                    __result.Add(__compiled);
+                }
+            }
+
+            void __update2((int position, PropertyResolvingMode mode) __key, object __object) {
+                var __key_alias_0 = $"__cosmos_<>position_{__key.position}";
+                var __key_alias_1 = (__key_alias_0, __key.mode);
+                if (!__named_cache.ContainsKey(__key_alias_1)) {
+                    var __compiled = _messageParameterResolver.CreateProperty(__key_alias_0, __object, __key.mode, __key.position);
+                    __named_cache.Add(__key_alias_1, __compiled);
+                    __positional_cache.Add(__key, __compiled);
+                    __result.Add(__compiled);
+                }
+            }
         }
 
         void PrepareForPropertyToken(IEnumerable<MessageTemplateToken> tokens,
             out List<(int position, PropertyResolvingMode mode)> positionalPropertyInfoList,
-            out List<(string name, PropertyResolvingMode mode)> namedPropertyInfoList) {
+            out List<(string name, PropertyResolvingMode mode)> namedPropertyInfoList,
+            out Dictionary<string, int> namedPropertyOffsetInfoDict) {
 
             positionalPropertyInfoList = new List<(int, PropertyResolvingMode)>();
             namedPropertyInfoList = new List<(string name, PropertyResolvingMode mode)>();
+            namedPropertyOffsetInfoDict = new Dictionary<string, int>();
+            var propertyIndex = 0;
 
             foreach (var token in tokens) {
                 if (token is PositionalPropertyToken propertyToken0 && propertyToken0.TokenRenderType == TokenRenderTypes.AsPositionalProperty) {
@@ -61,6 +146,8 @@ namespace Cosmos.Logging.Core.ObjectResolving {
                     if (!Exists1(namedPropertyInfoList, name, resolvingMode)) {
                         namedPropertyInfoList.Add((name, resolvingMode));
                     }
+
+                    propertyIndex = Next(namedPropertyOffsetInfoDict, name, propertyIndex);
                 }
             }
 
@@ -70,6 +157,11 @@ namespace Cosmos.Logging.Core.ObjectResolving {
 
             bool Exists1(IEnumerable<(string name, PropertyResolvingMode mode)> __infos, string name, PropertyResolvingMode mode) {
                 return __infos.Any(x => x.name == name && x.mode == mode);
+            }
+
+            int Next(Dictionary<string, int> __infos, string name, int offset) {
+                if (!__infos.ContainsKey(name)) __infos.Add(name, offset++);
+                return offset;
             }
         }
     }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/Rules/SimpleResolveRule.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/Rules/SimpleResolveRule.cs
@@ -4,11 +4,9 @@ using Cosmos.Logging.Events;
 
 namespace Cosmos.Logging.Core.ObjectResolving.Rules {
     internal class SimpleResolveRule : IScalarResolveRule {
-        readonly HashSet<Type> _scalarTypes;
+        private readonly HashSet<Type> _scalarTypes;
 
-        public SimpleResolveRule(IEnumerable<Type> scalarTypes) {
-            _scalarTypes = new HashSet<Type>(scalarTypes);
-        }
+        public SimpleResolveRule(IEnumerable<Type> scalarTypes) => _scalarTypes = new HashSet<Type>(scalarTypes);
 
         public bool TryResolve(object value, out MessagePropertyValue result) {
             result = _scalarTypes.Contains(value.GetType()) ? new ScalarValue(value) : null;

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/TypeFeeler.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/TypeFeeler.cs
@@ -60,7 +60,7 @@ namespace Cosmos.Logging.Core.ObjectResolving {
         }
 
         public static bool TryResolveCompilerGeneratedType(object value, PropertyResolvingMode mode, NestParameterResolver nest, Type typeOfValue,
-            bool raiseException, int positionalIndex, out MessagePropertyValue result) {
+            bool raiseException, int positionalValue, out MessagePropertyValue result) {
             if (mode == PropertyResolvingMode.Destructure) {
 
                 result = new StructureValue(StructureElements(), Tag());
@@ -89,7 +89,7 @@ namespace Cosmos.Logging.Core.ObjectResolving {
                             propertyValue = $"Threw an exception at: {ex.InnerException?.GetType().Name}";
                         }
 
-                        yield return new MessageProperty(property.Name, positionalIndex, nest.CreatePropertyValue(propertyValue, PropertyResolvingMode.Destructure));
+                        yield return new MessageProperty(property.Name, positionalValue, nest.CreatePropertyValue(propertyValue, PropertyResolvingMode.Destructure));
                     }
                 }
             }

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/TypeFeeler.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/TypeFeeler.cs
@@ -78,10 +78,12 @@ namespace Cosmos.Logging.Core.ObjectResolving {
                         try {
                             propertyValue = property.GetValue(value);
                         }
-                        catch (TargetParameterCountException ex) {
+                        catch (TargetParameterCountException) {
+                            InternalLogger.WriteLine("The property accessor '{0}' is a non-default indexer", property);
                             continue;
                         }
                         catch (TargetInvocationException ex) {
+                            InternalLogger.WriteLine("The property accessor '{0}' threw exception: {1}", property, ex);
                             if (raiseException)
                                 throw;
                             propertyValue = $"Threw an exception at: {ex.InnerException?.GetType().Name}";

--- a/Logging/src/Cosmos.Logging/Core/ObjectResolving/TypeFeeler.cs
+++ b/Logging/src/Cosmos.Logging/Core/ObjectResolving/TypeFeeler.cs
@@ -60,7 +60,7 @@ namespace Cosmos.Logging.Core.ObjectResolving {
         }
 
         public static bool TryResolveCompilerGeneratedType(object value, PropertyResolvingMode mode, NestParameterResolver nest, Type typeOfValue,
-            bool raiseException, int index, out MessagePropertyValue result) {
+            bool raiseException, int positionalIndex, out MessagePropertyValue result) {
             if (mode == PropertyResolvingMode.Destructure) {
 
                 result = new StructureValue(StructureElements(), Tag());
@@ -87,7 +87,7 @@ namespace Cosmos.Logging.Core.ObjectResolving {
                             propertyValue = $"Threw an exception at: {ex.InnerException?.GetType().Name}";
                         }
 
-                        yield return new MessageProperty(property.Name, index, nest.CreatePropertyValue(propertyValue, PropertyResolvingMode.Destructure));
+                        yield return new MessageProperty(property.Name, positionalIndex, nest.CreatePropertyValue(propertyValue, PropertyResolvingMode.Destructure));
                     }
                 }
             }

--- a/Logging/src/Cosmos.Logging/Events/IMessageProperty.cs
+++ b/Logging/src/Cosmos.Logging/Events/IMessageProperty.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cosmos.Logging.Events {
     public interface IMessageProperty {
-        
+        string Name { get; }
+        MessagePropertyValue Value { get; }
     }
 }

--- a/Logging/src/Cosmos.Logging/Events/LogEvent.cs
+++ b/Logging/src/Cosmos.Logging/Events/LogEvent.cs
@@ -61,6 +61,7 @@ namespace Cosmos.Logging.Events {
         private void UpdateProperty(IEnumerable<MessageProperty> properties) {
             Console.WriteLine("开始处理 Message properties，但目前尚在开发中...");
             if (properties == null) return;
+            
             //todo
         }
 

--- a/Logging/src/Cosmos.Logging/Events/LogEvent.cs
+++ b/Logging/src/Cosmos.Logging/Events/LogEvent.cs
@@ -8,9 +8,9 @@ namespace Cosmos.Logging.Events {
     public class LogEvent {
         private readonly AdditionalOptContext _additionalOptContext;
 
-        private readonly Dictionary<string, MessagePropertyValue> _namedProperties = new Dictionary<string, MessagePropertyValue>();
-        private readonly Dictionary<int, MessagePropertyValue> _positionalProperties = new Dictionary<int, MessagePropertyValue>();
-        private readonly Dictionary<string, ExtraMessageProperty> _extraMessageProperties = new Dictionary<string, ExtraMessageProperty>();
+        private readonly Dictionary<(string name, PropertyResolvingMode mode), MessagePropertyValue> _namedProperties;
+        private readonly Dictionary<(int position, PropertyResolvingMode mode), MessagePropertyValue> _positionalProperties;
+        private readonly Dictionary<string, ExtraMessageProperty> _extraMessageProperties;
 
         public LogEvent(
             DateTimeOffset timestamp,
@@ -18,15 +18,25 @@ namespace Cosmos.Logging.Events {
             MessageTemplate messageTemplate,
             Exception exception,
             LogEventSendMode sendMode,
-            IEnumerable<MessageProperty> messageProperties,
+            Dictionary<(string name, PropertyResolvingMode mode), MessageProperty> namedMessageProperties,
+            Dictionary<(int position, PropertyResolvingMode mode), MessageProperty> positionalMessageProperties,
             AdditionalOptContext additionalOptContext) {
+
+            if (namedMessageProperties == null) throw new ArgumentNullException(nameof(namedMessageProperties));
+            if (positionalMessageProperties == null) throw new ArgumentNullException(nameof(positionalMessageProperties));
+
             Timestamp = timestamp;
             Level = level;
             Exception = exception;
             SendMode = sendMode;
             MessageTemplate = messageTemplate ?? throw new ArgumentNullException(nameof(messageTemplate));
             _additionalOptContext = additionalOptContext ?? new AdditionalOptContext();
-            UpdateProperty(messageProperties);
+
+            _namedProperties = new Dictionary<(string name, PropertyResolvingMode mode), MessagePropertyValue>();
+            _positionalProperties = new Dictionary<(int position, PropertyResolvingMode mode), MessagePropertyValue>();
+            _extraMessageProperties = new Dictionary<string, ExtraMessageProperty>();
+
+            UpdateProperty(namedMessageProperties, positionalMessageProperties);
         }
 
         public DateTimeOffset Timestamp { get; }
@@ -38,11 +48,11 @@ namespace Cosmos.Logging.Events {
         #region Reder Message
 
         public void RenderMessage(TextWriter output, IFormatProvider provider = null) {
-            MessageTemplate.Render(NamedProperties, output, provider);
+            MessageTemplate.Render(NamedProperties, PositionalProperties, output, provider);
         }
 
         public string RenderMessage(IFormatProvider provider = null) {
-            return MessageTemplate.Render(NamedProperties, provider);
+            return MessageTemplate.Render(NamedProperties, PositionalProperties, provider);
         }
 
         #endregion
@@ -56,28 +66,15 @@ namespace Cosmos.Logging.Events {
 
         #region Normal Message Properties
 
-        public IReadOnlyDictionary<string, MessagePropertyValue> NamedProperties => _namedProperties;
+        public IReadOnlyDictionary<(string name, PropertyResolvingMode mode), MessagePropertyValue> NamedProperties => _namedProperties;
 
-        private void UpdateProperty(IEnumerable<MessageProperty> properties) {
-            Console.WriteLine("开始处理 Message properties，但目前尚在开发中...");
-            if (properties == null) return;
-            
-            //todo
-        }
+        public IReadOnlyDictionary<(int position, PropertyResolvingMode mode), MessagePropertyValue> PositionalProperties => _positionalProperties;
 
-        public void AddOrUpdateProperty(MessageProperty property) {
-            if (property == null) throw new ArgumentNullException(nameof(property));
-            _namedProperties[property.Name] = property.Value;
-        }
-
-        public void AddPropertyIfAbsent(MessageProperty property) {
-            if (property == null) throw new ArgumentNullException(nameof(property));
-            if (!_namedProperties.ContainsKey(property.Name))
-                _namedProperties.Add(property.Name, property.Value);
-        }
-
-        public void RemoveProperty(string propertyName) {
-            _namedProperties.Remove(propertyName);
+        private void UpdateProperty(
+            Dictionary<(string name, PropertyResolvingMode mode), MessageProperty> namedMessageProperties,
+            Dictionary<(int position, PropertyResolvingMode mode), MessageProperty> positionalMessageProperties) {
+            foreach (var prop in namedMessageProperties) _namedProperties.Add(prop.Key, prop.Value.Value);
+            foreach (var prop in positionalMessageProperties) _positionalProperties.Add(prop.Key, prop.Value.Value);
         }
 
         #endregion

--- a/Logging/src/Cosmos.Logging/Events/MessageProperty.cs
+++ b/Logging/src/Cosmos.Logging/Events/MessageProperty.cs
@@ -11,7 +11,7 @@ namespace Cosmos.Logging.Events {
 
         public string Name { get; }
         public MessagePropertyValue Value { get; }
-        public readonly int PositionalIndex;
+        public int PositionalIndex { get; set; }
         
         public bool AsNamedProperty { get; set; }
         public bool AsPositionalProperty { get; set; }

--- a/Logging/src/Cosmos.Logging/Events/MessageProperty.cs
+++ b/Logging/src/Cosmos.Logging/Events/MessageProperty.cs
@@ -2,19 +2,22 @@
 
 namespace Cosmos.Logging.Events {
     public class MessageProperty : IMessageProperty {
-        public MessageProperty(string name, int index, MessagePropertyValue value) {
-            CheckParams(name, index, value);
+        public MessageProperty(string name, int positionalIndex, MessagePropertyValue value) {
+            CheckParams(name, positionalIndex, value);
             Name = name;
             Value = value;
-            Index = index;
+            PositionalIndex = positionalIndex;
         }
 
         public string Name { get; }
         public MessagePropertyValue Value { get; }
-        public readonly int Index;
+        public readonly int PositionalIndex;
+        
+        public bool AsNamedProperty { get; set; }
+        public bool AsPositionalProperty { get; set; }
 
-        private static void CheckParams(string name, int index, MessagePropertyValue value) {
-            if (index < 0) throw new ArgumentOutOfRangeException(nameof(index));
+        private static void CheckParams(string name, int positionalIndex, MessagePropertyValue value) {
+            if (positionalIndex < -1) throw new ArgumentOutOfRangeException(nameof(positionalIndex));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
             if (value == null) throw new ArgumentNullException(nameof(value));
         }

--- a/Logging/src/Cosmos.Logging/Events/MessageProperty.cs
+++ b/Logging/src/Cosmos.Logging/Events/MessageProperty.cs
@@ -2,22 +2,22 @@
 
 namespace Cosmos.Logging.Events {
     public class MessageProperty : IMessageProperty {
-        public MessageProperty(string name, int positionalIndex, MessagePropertyValue value) {
-            CheckParams(name, positionalIndex, value);
+        public MessageProperty(string name, int positionalValue, MessagePropertyValue value) {
+            CheckParams(name, positionalValue, value);
             Name = name;
             Value = value;
-            PositionalIndex = positionalIndex;
+            PositionalValue = positionalValue;
         }
 
         public string Name { get; }
         public MessagePropertyValue Value { get; }
-        public int PositionalIndex { get; set; }
-        
+        public readonly int PositionalValue;
+
         public bool AsNamedProperty { get; set; }
         public bool AsPositionalProperty { get; set; }
 
-        private static void CheckParams(string name, int positionalIndex, MessagePropertyValue value) {
-            if (positionalIndex < -1) throw new ArgumentOutOfRangeException(nameof(positionalIndex));
+        private static void CheckParams(string name, int positionalValue, MessagePropertyValue value) {
+            if (positionalValue < -1) throw new ArgumentOutOfRangeException(nameof(positionalValue));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
             if (value == null) throw new ArgumentNullException(nameof(value));
         }

--- a/Logging/src/Cosmos.Logging/Events/MessagePropertyValue.Scalar.cs
+++ b/Logging/src/Cosmos.Logging/Events/MessagePropertyValue.Scalar.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Cosmos.Logging.Core.Extensions;
 using Cosmos.Logging.Formattings;
 
 namespace Cosmos.Logging.Events {
@@ -29,35 +30,28 @@ namespace Cosmos.Logging.Events {
 
         internal static void Render(object value, TextWriter output, string format = null, IFormatProvider formatProvider = null) {
             if (output == null) throw new ArgumentNullException(nameof(output));
+            IEnumerable<FormatEvent> __f(string ____f) => FormatCommandFactory.CreateCommandEvent(____f);
 
             if (value == null) {
-                output.Write("null");
+                output.Write(__f(format).ToFormat("null", formatProvider));
                 return;
             }
 
             if (value is string s) {
-                var formatEvents = FormatCommandFactory.CreateCommandEvent(format);
-                if (formatEvents != null && !formatEvents.Any()) {
-                    var orderedCmds = formatEvents.OrderBy(o => o.Sort);
-                    foreach (var cmd in orderedCmds) {
-                        s = cmd.Command(s, formatProvider) as string;
-                    }
-                }
-
-                output.Write(s);
+                output.Write(__f(format).ToFormat(s, formatProvider));
                 return;
             }
 
             if (formatProvider != null) {
                 var custom = (ICustomFormatter) formatProvider.GetFormat(typeof(ICustomFormatter));
                 if (custom != null) {
-                    output.Write(custom.Format(format, value, formatProvider));
+                    output.Write(__f(format).ToFormat(custom.Format(format, value, formatProvider), formatProvider));
                     return;
                 }
             }
 
             if (value is IFormattable f) {
-                output.Write(f.ToString(format, formatProvider ?? CultureInfo.InvariantCulture));
+                output.Write(__f(format).ToFormat(f.ToString(format, formatProvider ?? CultureInfo.InvariantCulture), formatProvider));
                 return;
             }
 
@@ -69,29 +63,25 @@ namespace Cosmos.Logging.Events {
             if (output == null) throw new ArgumentNullException(nameof(output));
 
             if (value == null) {
-                output.Write("null");
+                output.Write(formatFuncs.ToFormat("null", formatProvider));
                 return;
             }
 
-            if (value is string s && formatFuncs != null && !formatFuncs.Any()) {
-                foreach (var cmd in formatFuncs) {
-                    s = cmd(s, formatProvider) as string;
-                }
-
-                output.Write(s);
+            if (value is string s) {
+                output.Write(formatFuncs.ToFormat(s, formatProvider));
                 return;
             }
 
             if (formatProvider != null) {
                 var custom = (ICustomFormatter) formatProvider.GetFormat(typeof(ICustomFormatter));
                 if (custom != null) {
-                    output.Write(custom.Format(originFormat, value, formatProvider));
+                    output.Write(formatFuncs.ToFormat(custom.Format(originFormat, value, formatProvider), formatProvider));
                     return;
                 }
             }
 
             if (value is IFormattable f) {
-                output.Write(f.ToString(originFormat, formatProvider ?? CultureInfo.InvariantCulture));
+                output.Write(formatFuncs.ToFormat(f.ToString(originFormat, formatProvider ?? CultureInfo.InvariantCulture), formatProvider));
                 return;
             }
 
@@ -102,30 +92,25 @@ namespace Cosmos.Logging.Events {
             if (output == null) throw new ArgumentNullException(nameof(output));
 
             if (value == null) {
-                output.Write("null");
+                output.Write(formatEvents.ToFormat("null", formatProvider));
                 return;
             }
 
-            if (value is string s && formatEvents != null && !formatEvents.Any()) {
-                var orderedEvents = formatEvents.OrderBy(o => o.Sort);
-                foreach (var cmd in orderedEvents) {
-                    s = cmd.Command(s, formatProvider) as string;
-                }
-
-                output.Write(s);
+            if (value is string s) {
+                output.Write(formatEvents.ToFormat(s, formatProvider));
                 return;
             }
 
             if (formatProvider != null) {
                 var custom = (ICustomFormatter) formatProvider.GetFormat(typeof(ICustomFormatter));
                 if (custom != null) {
-                    output.Write(custom.Format(originFormat, value, formatProvider));
+                    output.Write(formatEvents.ToFormat(custom.Format(originFormat, value, formatProvider), formatProvider));
                     return;
                 }
             }
 
             if (value is IFormattable f) {
-                output.Write(f.ToString(originFormat, formatProvider ?? CultureInfo.InvariantCulture));
+                output.Write(formatEvents.ToFormat(f.ToString(originFormat, formatProvider ?? CultureInfo.InvariantCulture), formatProvider));
                 return;
             }
 

--- a/Logging/src/Cosmos.Logging/LoggerBase.cs
+++ b/Logging/src/Cosmos.Logging/LoggerBase.cs
@@ -54,9 +54,12 @@ namespace Cosmos.Logging {
             if (!IsEnabled(level)) return;
             if (string.IsNullOrWhiteSpace(messageTemplate)) return;
 
-            _messageParameterProcessor.Process(messageTemplate, __as(messageTemplateParameters), out var parsedTemplate, out var parsedProperties);
+            _messageParameterProcessor.Process(messageTemplate, __as(messageTemplateParameters),
+                out var parsedTemplate, out var parsedProperties,
+                out var namedMessageProperties, out var positionalMessageProperties);
 
-            var logEvent = new LogEvent(DateTimeOffset.Now, level, parsedTemplate, exception, sendMode, parsedProperties, context);
+            var logEvent = new LogEvent(DateTimeOffset.Now, level, parsedTemplate, exception, sendMode, 
+                namedMessageProperties, positionalMessageProperties, context);
 
             Dispatch(logEvent);
 

--- a/Logging/src/Cosmos.Logging/MessageTemplates/MessageTemplate.cs
+++ b/Logging/src/Cosmos.Logging/MessageTemplates/MessageTemplate.cs
@@ -18,8 +18,6 @@ namespace Cosmos.Logging.MessageTemplates {
         public MessageTemplate(string messageTemplate, IEnumerable<MessageTemplateToken> tokens) {
             Text = messageTemplate ?? throw new ArgumentNullException(nameof(messageTemplate));
             _tokens = tokens?.OrderBy(o => o.Index).ToArray() ?? throw new ArgumentNullException(nameof(tokens));
-            
-            
         }
 
         public string Text { get; }
@@ -29,6 +27,9 @@ namespace Cosmos.Logging.MessageTemplates {
         public IEnumerable<MessageTemplateToken> Tokens => _tokens;
 
         internal MessageTemplateToken[] TokenArray => _tokens;
+
+        internal int PropertyClassTokenCount
+            => _tokens.Count(x => x.TokenRenderType == TokenRenderTypes.AsProperty || x.TokenRenderType == TokenRenderTypes.AsPositionalProperty);
 
         public string Render(IReadOnlyDictionary<string, MessagePropertyValue> properties, IFormatProvider provider = null) {
             using (var output = new StringWriter(provider)) {

--- a/Logging/src/Cosmos.Logging/MessageTemplates/MessageTemplate.cs
+++ b/Logging/src/Cosmos.Logging/MessageTemplates/MessageTemplate.cs
@@ -31,17 +31,24 @@ namespace Cosmos.Logging.MessageTemplates {
         internal int PropertyClassTokenCount
             => _tokens.Count(x => x.TokenRenderType == TokenRenderTypes.AsProperty || x.TokenRenderType == TokenRenderTypes.AsPositionalProperty);
 
-        public string Render(IReadOnlyDictionary<string, MessagePropertyValue> properties, IFormatProvider provider = null) {
+        public string Render(
+            IReadOnlyDictionary<(string name, PropertyResolvingMode mode), MessagePropertyValue> namedMessageProperties,
+            IReadOnlyDictionary<(int position, PropertyResolvingMode mode), MessagePropertyValue> positionalMessageProperties,
+            IFormatProvider provider = null) {
             using (var output = new StringWriter(provider)) {
-                Render(properties, output, provider);
+                Render(namedMessageProperties, positionalMessageProperties, output, provider);
                 return output.ToString();
             }
         }
 
-        public void Render(IReadOnlyDictionary<string, MessagePropertyValue> properties, TextWriter output, IFormatProvider provider = null) {
-            if (properties == null) throw new ArgumentNullException(nameof(properties));
+        public void Render(
+            IReadOnlyDictionary<(string name, PropertyResolvingMode mode), MessagePropertyValue> namedMessageProperties,
+            IReadOnlyDictionary<(int position, PropertyResolvingMode mode), MessagePropertyValue> positionalMessageProperties,
+            TextWriter output, IFormatProvider provider = null) {
+            if (namedMessageProperties == null) throw new ArgumentNullException(nameof(namedMessageProperties));
+            if (positionalMessageProperties == null) throw new ArgumentNullException(nameof(positionalMessageProperties));
             if (output == null) throw new ArgumentNullException(nameof(output));
-            MessageTemplateRenderer.Render(this, properties, output, null, provider);
+            MessageTemplateRenderer.Render(this, namedMessageProperties, positionalMessageProperties, output, null, provider);
         }
 
         public override string ToString() => Text;

--- a/Logging/src/Cosmos.Logging/NullLogger.cs
+++ b/Logging/src/Cosmos.Logging/NullLogger.cs
@@ -265,7 +265,5 @@ namespace Cosmos.Logging {
         public void LogFatal<T1, T2, T3>(Exception exception, string messageTemplate, T1 paramObject1, T2 paramObject2, T3 paramObject3, Action<AdditionalOptContext> optCtxAct) { }
 
         public void LogFatal(Exception exception, string messageTemplate, Action<AdditionalOptContext> optCtxAct, params object[] paramObjects) { }
-
-
     }
 }

--- a/Logging/tests/Cosmos.Loggings.MessageTemplateTokenTests/Program.cs
+++ b/Logging/tests/Cosmos.Loggings.MessageTemplateTokenTests/Program.cs
@@ -12,7 +12,7 @@ namespace Cosmos.Loggings.MessageTemplateTokenTests {
         static void Main(string[] args) {
             try {
                 LOGGER.Initialize().RunsOnConsole()
-                    .UseSampleLog(s=>s.Level = LogEventLevel.Information)
+                    .UseSampleLog(s => s.Level = LogEventLevel.Information)
                     .AllDone();
 
                 var logger = LOGGER.GetLogger("TOKEN_TESTS_SAMPLESINK");
@@ -98,8 +98,8 @@ namespace Cosmos.Loggings.MessageTemplateTokenTests {
 //                logger.Information("token test--> alexLEWIS {$1234567890:");
 //                logger.Information("token test--> {$789:111:3[ ]33}");
 //                logger.Information("token test--> forerunner {$ErrorToken:ErrorFormat:ErrorParams");
-                
-                
+
+
 //                logger.LogInformation(@"
 //
 //Google、{{AWS}}和{@Azure}都已经发表了声明，{$ConsoleHelloWorld:jpr30w}，说道：
@@ -113,21 +113,25 @@ namespace Cosmos.Loggings.MessageTemplateTokenTests {
 //来自{$Amazon:yyyyMMdd[ ]HH[:]mm[:]ss}的Richard Harvey对此进行了确认。
 //
 //");
-                
-                logger.LogInformation("position test{10}");
-                logger.LogInformation("position test{10} ");
-                logger.LogInformation("position test{10:}");
-                logger.LogInformation("position test{10:} ");
-                logger.LogInformation("position test{10::}");
-                logger.LogInformation("position test{10::} ");
-                logger.LogInformation("position test{10:w}");
-                logger.LogInformation("position test{10:w:} ");
-                
+
+//                logger.LogInformation("position test{10}");
+//                logger.LogInformation("position test{10} ");
+//                logger.LogInformation("position test{10:}");
+//                logger.LogInformation("position test{10:} ");
+//                logger.LogInformation("position test{10::}");
+//                logger.LogInformation("position test{10::} ");
+//                logger.LogInformation("position test{10:w}");
+//                logger.LogInformation("position test{10:w:} ");
+
+                logger.LogInformation("token test: {@Hello:U}, {0:U}, {@World},{1}, {$ConsoleHelloWorld}, {$Hello}, {@Alewix}, {3}", new {Hello = "_hello_"}, "?world?");
+                logger.LogInformation("token test: {@Hello}, {0}, {@World}", new {Hello = "_hello_", World = "_world_"}, "?world?");
+
                 Console.WriteLine("I'm live");
             }
             catch (Exception e) {
                 Console.WriteLine(e.Message);
                 Console.WriteLine(e.Source);
+
                 Console.WriteLine(e.StackTrace);
             }
 


### PR DESCRIPTION
绑定逻辑为：
1. {{Token}} --> TextToken / NullTextToken
2. {$Token} --> 预置指令
3. {@Token} --> 自定义对象绑定（基于名称）
4. {0} --> 自定义对象绑定（基于定位）

a. 对于 3. ，识别用户给定的匿名类型的一级成员名称，名称匹配的完成绑定（大小写不敏感）
b. 对于 a. 阶段未完成绑定的具名Token，根据其位于具名Token的位置（从0开始计），与对应位置的自定义对象进行绑定（无视名称，仅对位置进行判断）

5. {$nlog#Token} --> 调用由 Sinks.NLog 提供的预置指令（此处 nlog 为泛指，亦可为 {$log4net#Token}）

6. 关于格式化指令

a. 在Token右侧使用冒号分割，{@Token:format} / {0:format} / {$Token:format}
b. 支持以下格式化指令：
- U  - 转为大写；
- w -- 转为小写；
- j -- 转为 Json；
- pr20 或 pl30 -- RightPad/LeftPad，后面接的数字表示空几个格

高级格式化指令（将影响解析的流程，并可能会影响性能的指令）：

S -- 对应 PropertyResolvingMode.Stringify，将所有类型转换为 String
D -- 将已知类型转换为 Scalar，将对象、数组/集合转换为 Sequence 和 Structure
(default) -- 如果不提供高级格式化指令，则使用默认值，将已知的类型和对象转换为 Scalar，将数组/集合类型转换为 Sequence

7. 在format指令右侧提供自定义参数，{@Token:format:params} / {@format::params}

**目前 7. 尚未启用**

8. 针对特殊格式的特殊处理（比如 {$Token}  的结尾大括号忘记打上了），尽量使不合法的占位符处理为合法占位符

9. 针对未能被 8. 处理到的非法占位符、未能绑定到自定义对象的占位符、未能绑定到预置指令的占位符，将按照 1. 的渲染方式进行处理（对于 4.，将识别为 NullPositionalPropertyToken，进而根据 NullTextToken 的方式进行渲染）

10.  that's all.